### PR TITLE
Tiny capitalization fix for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Once you have an instance of CharacterSet you can use the following methods on i
   <dt>toHexString()</dt>
   <dd>Returns a hex string representation of this character set.</dd>
 
-  <dt>ToHexRangeString()</dt>
+  <dt>toHexRangeString()</dt>
   <dd>Returns a hex string representation with ranges of this character set.</dd>
 </dl>
 


### PR DESCRIPTION
I realize this is the most hilariously pedantic thing to PR, but here you go, tiny fix in the documentation.

Love this library btw!  I'm using it in a webpack thingy I'm working on to make custom font subsets.  Thank you for making it 🙏 